### PR TITLE
feat: Prepare repository for Vercel deployment

### DIFF
--- a/.vercel-ignore
+++ b/.vercel-ignore
@@ -1,0 +1,1 @@
+backend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,3 +24,11 @@ This app consists of two main routes,
 3. And before pushing to the repo, `npm run build` to catch any typescript errors (TODO: pre-commit hook)
 
 Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel), [Netlify](https://create.t3.gg/en/deployment/netlify) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
+
+## Vercel Deployment
+
+To deploy this frontend to Vercel, you will need to set the following environment variable:
+
+- `NEXT_PUBLIC_BACKEND_URL`: The URL of the deployed backend API.
+
+You can set this in the Vercel project settings.

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,8 @@
+{
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/next"
+    }
+  ]
+}

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,8 +1,0 @@
-{
-  "builds": [
-    {
-      "src": "package.json",
-      "use": "@vercel/next"
-    }
-  ]
-}


### PR DESCRIPTION
This commit prepares the repository for deploying the frontend to Vercel.

- Adds a `.vercel-ignore` file to the root to prevent the `backend` directory from being uploaded to Vercel.
- Adds a `vercel.json` file to the `frontend` directory to explicitly define the build configuration for Vercel.
- Updates the `frontend/README.md` with instructions on how to deploy to Vercel, including the necessary `NEXT_PUBLIC_BACKEND_URL` environment variable.